### PR TITLE
Fixed problems with garbage collection, new SDK and missing DVTPlugInCompatibilityUUIDs from the Plist file

### DIFF
--- a/src/InstaCodesPlugin.xcodeproj/project.pbxproj
+++ b/src/InstaCodesPlugin.xcodeproj/project.pbxproj
@@ -124,7 +124,7 @@
 		EFE4EDD616CE1F5A004CC72A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = "Eugene Kolpakov";
 			};
 			buildConfigurationList = EFE4EDD916CE1F5A004CC72A /* Build configuration list for PBXProject "InstaCodesPlugin" */;
@@ -183,7 +183,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -215,7 +214,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_CONSTANT_CONVERSION = YES;

--- a/src/InstaCodesPlugin.xcodeproj/project.pbxproj
+++ b/src/InstaCodesPlugin.xcodeproj/project.pbxproj
@@ -242,7 +242,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEPLOYMENT_LOCATION = YES;
 				DSTROOT = "$(HOME)";
-				GCC_ENABLE_OBJC_GC = supported;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "InstaCodesPlugin/InstaCodesPlugin-Prefix.pch";
@@ -261,7 +260,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEPLOYMENT_LOCATION = YES;
 				DSTROOT = "$(HOME)";
-				GCC_ENABLE_OBJC_GC = supported;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "InstaCodesPlugin/InstaCodesPlugin-Prefix.pch";

--- a/src/InstaCodesPlugin.xcodeproj/project.pbxproj
+++ b/src/InstaCodesPlugin.xcodeproj/project.pbxproj
@@ -249,7 +249,7 @@
 				INSTALL_PATH = "/Library/Application Support/Developer/Shared/Xcode/Plug-ins";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.7;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = xcplugin;
 			};
 			name = Debug;
@@ -267,7 +267,7 @@
 				INSTALL_PATH = "/Library/Application Support/Developer/Shared/Xcode/Plug-ins";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.7;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = xcplugin;
 			};
 			name = Release;

--- a/src/InstaCodesPlugin/InstaCodesPlugin-Info.plist
+++ b/src/InstaCodesPlugin/InstaCodesPlugin-Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Fixed [issue 2](https://github.com/parametr/instacodes-for-xcode/issues/2).

Also, started using the newest Mac OS SDK and removed deprecated option for garbage collection.
